### PR TITLE
doc/website: Ent focused announcementBar

### DIFF
--- a/doc/website/docusaurus.config.js
+++ b/doc/website/docusaurus.config.js
@@ -253,12 +253,11 @@ const config = {
       `,
     },
     announcementBar: {
-      id: 'announcementBar-2', // Increment on change
-      // content: `⭐️ If you like Ent, give it a star on <a target="_blank" rel="noopener noreferrer" href="https://github.com/ent/ent">GitHub</a> and follow us on <a target="_blank" rel="noopener noreferrer" href="https://twitter.com/entgo_io" >Twitter</a> ${TwitterSvg}`,
-      content: `<a style="text-decoration: none;" target="_blank" rel="noopener noreferrer" href="https://twitter.com/Israel/status/1713931519620788538">The Ent Team Stands With Israel 🇮🇱</a>`,
+      id: 'announcementBar-3', // Increment on change
+      content: `⭐️ If you like Ent, give it a star on <a target="_blank" rel="noopener noreferrer" href="https://github.com/ent/ent">GitHub</a> and follow us on <a target="_blank" rel="noopener noreferrer" href="https://twitter.com/entgo_io" >Twitter</a> ${TwitterSvg}`,
       backgroundColor: '#fafbfc',
-      textColor: '#404756',
-      isCloseable: false,
+      textColor: '#091E42',
+      isCloseable: true,
     },
   }
 };


### PR DESCRIPTION
Reverting the announcementBar for https://entgo.io/docs to the generic Ent focused message from prior to https://github.com/ent/ent/pull/3792

I can understand why this messaging change was made on Oct 17, 2023 in the wake of the attacks and share my condemnation and condolences.

It's your project and you should do with it as you please. I harbour no ill intend. But I would submit that this political message can be removed >6 months on.